### PR TITLE
Trim SHA-1 hash length at 10 for consistency with dontet --info

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -43,7 +43,7 @@ namespace dotnetallversion
         static string GetHash(string versionfile)
         {
             var lines = File.ReadAllLines(versionfile);
-            return lines[0].Substring(0,8);
+            return lines[0].Substring(0,10);
         }
 
         static bool IsVersionFilePresent(string versionfile){


### PR DESCRIPTION
When you run `dotnet --info`, the SHA-1 hash is clipped to 10 hexadecimals, e.g.:

```
.NET Command Line Tools (1.0.0-rc4-004771)

Product Information:
 Version:            1.0.0-rc4-004771
 Commit SHA-1 hash:  4228198f0e

Runtime Environment:
 OS Name:     Mac OS X
 OS Version:  10.12
 OS Platform: Darwin
 RID:         osx.10.12-x64
 Base Path:   /usr/local/share/dotnet/sdk/1.0.0-rc4-004771
```

`dotnet-allversions` on the other hand shows only 8, so instead of `4228198f0e` like above, it shows `4228198f`. This PR aligns `dotnet-allversions` with what `dotnet --info` shows for sake of consistency.

```
Installed .Net versions are:
Active version: 1.0.0-preview2

Product Information:
 Version:            1.0.0-preview2-003156
 Commit SHA-1 hash:  33dabee5d8

Product Information:
 Version:            1.0.0-rc4-004771
 Commit SHA-1 hash:  4228198f0e

Runtime Environment:
 OS Name:     Mac OS X
 OS Version:  10.12
 OS Platform: Darwin
 RID:         osx.10.12-x64
```
