### PR TITLE
Show base path of each installed version

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -29,6 +29,7 @@ namespace dotnetallversion
                     string template = $@"Product Information:
  Version:            {version}
  Commit SHA-1 hash:  {hash}
+ Base Path:          {item.FullName}
 ";
                     Console.WriteLine(template);
                 }


### PR DESCRIPTION
This PR adds the base path of each installed version.

## Example Output

```
Installed .Net versions are:
Active version: 1.0.0-preview2

Product Information:
 Version:            1.0.0-preview2-003156
 Commit SHA-1 hash:  33dabee5
 Base Path:          /usr/local/share/dotnet/sdk/1.0.0-preview2-003156

Product Information:
 Version:            1.0.0-rc4-004771
 Commit SHA-1 hash:  4228198f
 Base Path:          /usr/local/share/dotnet/sdk/1.0.0-rc4-004771

Runtime Environment:
 OS Name:     Mac OS X
 OS Version:  10.12
 OS Platform: Darwin
 RID:         osx.10.12-x64
```
